### PR TITLE
chore(actions): Create release workflow for automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+run-name: ✨ Release ${{ github.ref_name }} triggered by @${{ github.actor }}
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Release and Generate Notes
+        uses: softprops/action-gh-release@v1
+        with:
+          name: github-enterprise-mcp ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automates GitHub release creation when a SemVer tag (`vX.Y.Z`) is pushed.

**Key Features:**
- Triggered on SemVer tag push (`v*.*.*`).
- Uses `softprops/action-gh-release` to create the release.
- Automatically generates release notes (`generate_release_notes: true`).

Pushing a tag now automatically handles release creation and notes.